### PR TITLE
generateTest/testCallID and results size check fixed

### DIFF
--- a/src/components/GenerateTest.vue
+++ b/src/components/GenerateTest.vue
@@ -131,13 +131,13 @@ export default {
                         else 
                         {
                           this.testResultsSize = doneTestResponse.data.results.length;
+                          this.testCallId = id;
 
-                          if(doneTestResponse.data.is_finished || doneTestResponse.data.results.length === this.testAmount)
+                          if(doneTestResponse.data.is_finished || doneTestResponse.data.results.length === this.edt_queries)
                           {
                             clearInterval(this.timer);
 
                             this.isTestCallCompleted = true;
-                            this.testCallId = id;
                           }
                         }
                       });


### PR DESCRIPTION
testCallId set even before the test is complete
interval cleared on results == queries